### PR TITLE
Fix removeTopBar on latest Discord, again

### DIFF
--- a/src/removeTopBar/index.tsx
+++ b/src/removeTopBar/index.tsx
@@ -6,7 +6,7 @@ export const patches: ExtensionWebExports["patches"] = [
   {
     find: "showNotificationsInbox",
     replace: {
-      match: /(?<=\}\);)(?=return.+?trailing:\(0,\i\.jsxs\)\(\i\.Fragment,{children:(\[.*?\)\]))/,
+      match: /(?<=[}"]\);)(?=return.+?trailing:\(0,\i\.jsxs\)\(\i\.Fragment,{children:(\[.*?\)\]))/,
       replacement: (_, buttons) => `require("removeTopBar_entrypoint").storeButtons(${buttons}); return null;`
     }
   },
@@ -46,9 +46,6 @@ export const webpackModules: ExtensionWebExports["webpackModules"] = {
       {
         ext: "common",
         id: "stores"
-      },
-      {
-        id: "discord/components/common/index"
       },
       {
         ext: "common",

--- a/src/removeTopBar/manifest.json
+++ b/src/removeTopBar/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://moonlight-mod.github.io/manifest.schema.json",
   "id": "removeTopBar",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "apiLevel": 2,
   "meta": {
     "name": "Remove Title Bar",


### PR DESCRIPTION
`discord/components/common/index` doesn't exist anymore, and a regex was a bit fragile (maybe still is, but I couldn't think of a better way to write it).